### PR TITLE
fixed: allow_admin address error in config.yaml

### DIFF
--- a/example/apisix_conf/config.yaml
+++ b/example/apisix_conf/config.yaml
@@ -5,7 +5,7 @@ apisix:
   enable_admin: true
   enable_debug: true
   allow_admin:
-    - 127.0.0.1/24
+    - 127.0.0.0/24
   port_admin: 9180
   real_ip_header: "X-Real-IP"
   real_ip_from:


### PR DESCRIPTION
nginx: [warn] low address bits of 127.0.0.1/24 are meaningless in /usr/local/apisix/conf/nginx.conf:82
nginx: [warn] low address bits of 127.0.0.1/24 are meaningless in /usr/local/apisix/conf/nginx.conf:112

fixed 127.0.0.1/24 to 127.0.0.0/24
see: https://github.com/iresty/apisix#dashboard